### PR TITLE
Add Syoka plugin: RSS candidate listing, admin UI and draft creation

### DIFF
--- a/syoka/includes/admin.php
+++ b/syoka/includes/admin.php
@@ -1,0 +1,357 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_action( 'admin_menu', 'syoka_register_admin_menu' );
+add_action( 'admin_init', 'syoka_handle_admin_actions' );
+add_action( 'admin_notices', 'syoka_render_admin_notices' );
+
+function syoka_register_admin_menu() {
+    add_menu_page(
+        __( 'Syoka', 'syoka' ),
+        __( 'Syoka', 'syoka' ),
+        'manage_options',
+        'syoka_feeds',
+        'syoka_render_feeds_page',
+        'dashicons-rss'
+    );
+
+    add_submenu_page(
+        'syoka_feeds',
+        __( 'RSSサイト管理', 'syoka' ),
+        __( 'RSSサイト管理', 'syoka' ),
+        'manage_options',
+        'syoka_feeds',
+        'syoka_render_feeds_page'
+    );
+
+    add_submenu_page(
+        'syoka_feeds',
+        __( '候補一覧', 'syoka' ),
+        __( '候補一覧', 'syoka' ),
+        'manage_options',
+        'syoka_candidates',
+        'syoka_render_candidates_page'
+    );
+}
+
+function syoka_handle_admin_actions() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    if ( isset( $_POST['syoka_action'] ) && $_POST['syoka_action'] === 'save_feeds' ) {
+        check_admin_referer( 'syoka_save_feeds' );
+        syoka_handle_save_feeds();
+    }
+
+    if ( isset( $_GET['syoka_action'] ) && $_GET['syoka_action'] === 'refresh_feed' ) {
+        check_admin_referer( 'syoka_refresh_feed' );
+        $feed_url = isset( $_GET['feed_url'] ) ? esc_url_raw( wp_unslash( $_GET['feed_url'] ) ) : '';
+        if ( ! empty( $feed_url ) ) {
+            syoka_clear_feed_cache( $feed_url );
+            syoka_add_notice( 'success', __( 'キャッシュを削除して再取得します。', 'syoka' ) );
+        }
+    }
+
+    if ( isset( $_POST['syoka_action'] ) && $_POST['syoka_action'] === 'create_posts' ) {
+        check_admin_referer( 'syoka_create_posts' );
+        syoka_handle_create_posts();
+    }
+}
+
+function syoka_get_feeds() {
+    $feeds = get_option( SYOKA_FEEDS_OPTION, array() );
+    if ( ! is_array( $feeds ) ) {
+        $feeds = array();
+    }
+    return $feeds;
+}
+
+function syoka_save_feeds( $feeds ) {
+    update_option( SYOKA_FEEDS_OPTION, $feeds );
+}
+
+function syoka_handle_save_feeds() {
+    $urls = isset( $_POST['feed_url'] ) ? (array) wp_unslash( $_POST['feed_url'] ) : array();
+    $actives = isset( $_POST['feed_active'] ) ? (array) wp_unslash( $_POST['feed_active'] ) : array();
+    $deletes = isset( $_POST['feed_delete'] ) ? (array) wp_unslash( $_POST['feed_delete'] ) : array();
+
+    $feeds = array();
+
+    foreach ( $urls as $index => $url ) {
+        $url = esc_url_raw( $url );
+        if ( empty( $url ) ) {
+            continue;
+        }
+
+        if ( ! preg_match( '/^https?:\/\//i', $url ) ) {
+            continue;
+        }
+
+        if ( isset( $deletes[ $index ] ) ) {
+            continue;
+        }
+
+        $feeds[] = array(
+            'url'    => $url,
+            'active' => isset( $actives[ $index ] ) ? 1 : 0,
+        );
+    }
+
+    $new_url = isset( $_POST['new_feed_url'] ) ? esc_url_raw( wp_unslash( $_POST['new_feed_url'] ) ) : '';
+    $new_active = isset( $_POST['new_feed_active'] ) ? 1 : 0;
+
+    if ( ! empty( $new_url ) ) {
+        if ( ! preg_match( '/^https?:\/\//i', $new_url ) ) {
+            syoka_add_notice( 'error', __( '追加URLはhttp/httpsのみ有効です。', 'syoka' ) );
+        } elseif ( count( $feeds ) >= SYOKA_FEED_LIMIT ) {
+            syoka_add_notice( 'error', __( '登録できるRSSは最大10件までです。', 'syoka' ) );
+        } else {
+            $feeds[] = array(
+                'url'    => $new_url,
+                'active' => $new_active,
+            );
+        }
+    }
+
+    if ( count( $feeds ) > SYOKA_FEED_LIMIT ) {
+        $feeds = array_slice( $feeds, 0, SYOKA_FEED_LIMIT );
+        syoka_add_notice( 'error', __( 'RSSは最大10件までです。超過分は削除されました。', 'syoka' ) );
+    }
+
+    syoka_save_feeds( $feeds );
+    syoka_add_notice( 'success', __( 'RSSサイト設定を保存しました。', 'syoka' ) );
+}
+
+function syoka_handle_create_posts() {
+    $items = isset( $_POST['syoka_items'] ) ? (array) wp_unslash( $_POST['syoka_items'] ) : array();
+
+    if ( empty( $items ) ) {
+        syoka_add_notice( 'warning', __( '選択された記事がありません。', 'syoka' ) );
+        return;
+    }
+
+    foreach ( $items as $encoded ) {
+        $decoded = json_decode( base64_decode( $encoded ), true );
+        if ( ! is_array( $decoded ) ) {
+            syoka_add_notice( 'error', __( '記事データの解析に失敗しました。', 'syoka' ) );
+            continue;
+        }
+
+        $result = syoka_create_draft_post( $decoded );
+        if ( $result['status'] === 'success' ) {
+            $edit_link = get_edit_post_link( $result['post_id'], '' );
+            $message = __( '下書きを作成しました。', 'syoka' );
+            if ( $edit_link ) {
+                $message .= ' <a href="' . esc_url( $edit_link ) . '">' . esc_html__( '編集', 'syoka' ) . '</a>';
+            }
+            syoka_add_notice( 'success', $message );
+        } elseif ( $result['status'] === 'duplicate' ) {
+            syoka_add_notice( 'warning', __( '既存投稿があるためスキップしました。', 'syoka' ) );
+        } else {
+            syoka_add_notice( 'error', sprintf( __( '作成に失敗しました: %s', 'syoka' ), esc_html( $result['message'] ) ) );
+        }
+    }
+}
+
+function syoka_add_notice( $type, $message ) {
+    $notices = get_option( SYOKA_NOTICE_OPTION, array() );
+    if ( ! is_array( $notices ) ) {
+        $notices = array();
+    }
+    $notices[] = array(
+        'type'    => $type,
+        'message' => $message,
+    );
+    update_option( SYOKA_NOTICE_OPTION, $notices );
+}
+
+function syoka_render_admin_notices() {
+    $notices = get_option( SYOKA_NOTICE_OPTION, array() );
+    if ( empty( $notices ) || ! is_array( $notices ) ) {
+        return;
+    }
+
+    foreach ( $notices as $notice ) {
+        $type = isset( $notice['type'] ) ? $notice['type'] : 'info';
+        $message = isset( $notice['message'] ) ? $notice['message'] : '';
+
+        printf(
+            '<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+            esc_attr( $type ),
+            wp_kses_post( $message )
+        );
+    }
+
+    delete_option( SYOKA_NOTICE_OPTION );
+}
+
+function syoka_render_feeds_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $feeds = syoka_get_feeds();
+    ?>
+    <div class="wrap">
+        <h1><?php echo esc_html__( 'RSSサイト管理', 'syoka' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'syoka_save_feeds' ); ?>
+            <input type="hidden" name="syoka_action" value="save_feeds">
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th><?php echo esc_html__( '有効', 'syoka' ); ?></th>
+                        <th><?php echo esc_html__( 'RSS URL', 'syoka' ); ?></th>
+                        <th><?php echo esc_html__( '削除', 'syoka' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ( empty( $feeds ) ) : ?>
+                        <tr>
+                            <td colspan="3"><?php echo esc_html__( '登録済みのRSSがありません。', 'syoka' ); ?></td>
+                        </tr>
+                    <?php else : ?>
+                        <?php foreach ( $feeds as $index => $feed ) : ?>
+                            <tr>
+                                <td>
+                                    <input type="checkbox" name="feed_active[<?php echo esc_attr( $index ); ?>]" value="1" <?php checked( ! empty( $feed['active'] ) ); ?> />
+                                </td>
+                                <td>
+                                    <input type="url" class="regular-text" name="feed_url[<?php echo esc_attr( $index ); ?>]" value="<?php echo esc_url( $feed['url'] ); ?>" required />
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="feed_delete[<?php echo esc_attr( $index ); ?>]" value="1" />
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+
+            <h2><?php echo esc_html__( 'RSSを追加', 'syoka' ); ?></h2>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><?php echo esc_html__( 'RSS URL', 'syoka' ); ?></th>
+                    <td>
+                        <input type="url" class="regular-text" name="new_feed_url" placeholder="https://example.com/feed" />
+                        <label>
+                            <input type="checkbox" name="new_feed_active" value="1" />
+                            <?php echo esc_html__( '有効にする', 'syoka' ); ?>
+                        </label>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button( __( '保存', 'syoka' ) ); ?>
+        </form>
+        <p><?php echo esc_html__( '登録できるRSSは最大10件です。', 'syoka' ); ?></p>
+    </div>
+    <?php
+}
+
+function syoka_render_candidates_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $feeds = syoka_get_feeds();
+    ?>
+    <div class="wrap">
+        <h1><?php echo esc_html__( '候補一覧', 'syoka' ); ?></h1>
+
+        <form method="post">
+            <?php wp_nonce_field( 'syoka_create_posts' ); ?>
+            <input type="hidden" name="syoka_action" value="create_posts">
+
+            <?php if ( empty( $feeds ) ) : ?>
+                <p><?php echo esc_html__( 'RSSサイトが登録されていません。', 'syoka' ); ?></p>
+            <?php else : ?>
+                <?php foreach ( $feeds as $feed ) : ?>
+                    <?php if ( empty( $feed['active'] ) ) : ?>
+                        <?php continue; ?>
+                    <?php endif; ?>
+                    <?php
+                    $items = syoka_get_feed_items( $feed['url'] );
+                    if ( is_wp_error( $items ) ) {
+                        syoka_add_notice( 'error', sprintf( __( 'RSS取得に失敗しました: %s', 'syoka' ), esc_html( $items->get_error_message() ) ) );
+                        $items = array();
+                    }
+                    ?>
+                    <h2><?php echo esc_html( $feed['url'] ); ?></h2>
+                    <?php
+                    $refresh_url = wp_nonce_url(
+                        add_query_arg(
+                            array(
+                                'page'         => 'syoka_candidates',
+                                'syoka_action' => 'refresh_feed',
+                                'feed_url'     => rawurlencode( $feed['url'] ),
+                            ),
+                            admin_url( 'admin.php' )
+                        ),
+                        'syoka_refresh_feed'
+                    );
+                    ?>
+                    <p><a class="button" href="<?php echo esc_url( $refresh_url ); ?>"><?php echo esc_html__( '更新（再取得）', 'syoka' ); ?></a></p>
+                    <table class="widefat striped">
+                        <thead>
+                            <tr>
+                                <th><?php echo esc_html__( '選択', 'syoka' ); ?></th>
+                                <th><?php echo esc_html__( 'サムネイル', 'syoka' ); ?></th>
+                                <th><?php echo esc_html__( 'タイトル', 'syoka' ); ?></th>
+                                <th><?php echo esc_html__( '元URL', 'syoka' ); ?></th>
+                                <th><?php echo esc_html__( '日付', 'syoka' ); ?></th>
+                                <th><?php echo esc_html__( '状態', 'syoka' ); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if ( empty( $items ) ) : ?>
+                                <tr>
+                                    <td colspan="6"><?php echo esc_html__( '表示できる記事がありません。', 'syoka' ); ?></td>
+                                </tr>
+                            <?php else : ?>
+                                <?php foreach ( $items as $item ) : ?>
+                                    <?php
+                                    $is_duplicate = syoka_is_duplicate( $item['guid'], $item['link'] );
+                                    $encoded = base64_encode( wp_json_encode( $item ) );
+                                    ?>
+                                    <tr>
+                                        <td>
+                                            <?php if ( $is_duplicate ) : ?>
+                                                <input type="checkbox" disabled />
+                                            <?php else : ?>
+                                                <input type="checkbox" name="syoka_items[]" value="<?php echo esc_attr( $encoded ); ?>" />
+                                            <?php endif; ?>
+                                        </td>
+                                        <td>
+                                            <?php if ( ! empty( $item['image_url'] ) ) : ?>
+                                                <img src="<?php echo esc_url( $item['image_url'] ); ?>" alt="" style="width:80px;height:auto;" />
+                                            <?php else : ?>
+                                                <?php echo esc_html__( 'なし', 'syoka' ); ?>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td><?php echo esc_html( $item['title'] ); ?></td>
+                                        <td><a href="<?php echo esc_url( $item['link'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $item['link'] ); ?></a></td>
+                                        <td><?php echo esc_html( $item['date'] ); ?></td>
+                                        <td>
+                                            <?php if ( $is_duplicate ) : ?>
+                                                <span style="color:#999; font-weight:700;"><?php echo esc_html__( '投稿済み', 'syoka' ); ?></span>
+                                            <?php else : ?>
+                                                <?php echo esc_html__( '未投稿', 'syoka' ); ?>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                <?php endforeach; ?>
+            <?php endif; ?>
+
+            <?php submit_button( __( '選択した記事を下書きで作成', 'syoka' ) ); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/syoka/includes/feed.php
+++ b/syoka/includes/feed.php
@@ -1,0 +1,104 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function syoka_get_feed_items( $feed_url, $force_refresh = false ) {
+    $feed_url = esc_url_raw( $feed_url );
+    if ( empty( $feed_url ) ) {
+        return new WP_Error( 'syoka_invalid_url', __( 'Invalid feed URL.', 'syoka' ) );
+    }
+
+    $transient_key = 'syoka_feed_' . md5( $feed_url );
+    if ( $force_refresh ) {
+        delete_transient( $transient_key );
+    }
+
+    $cached = get_transient( $transient_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    require_once ABSPATH . WPINC . '/feed.php';
+
+    $feed = fetch_feed( $feed_url );
+    if ( is_wp_error( $feed ) ) {
+        return $feed;
+    }
+
+    $feed->set_item_limit( SYOKA_ITEMS_PER_FEED );
+    $items = $feed->get_items( 0, SYOKA_ITEMS_PER_FEED );
+
+    $normalized = array();
+    foreach ( $items as $item ) {
+        $guid = (string) $item->get_id();
+        $link = (string) $item->get_link();
+        $title = (string) $item->get_title();
+        $date = $item->get_date( 'Y-m-d H:i' );
+        $content = $item->get_content();
+        $description = $item->get_description();
+        $excerpt = '';
+
+        if ( ! empty( $description ) ) {
+            $excerpt = wp_kses_post( $description );
+        } elseif ( ! empty( $content ) ) {
+            $excerpt = wp_kses_post( $content );
+        }
+
+        $image_url = syoka_extract_image_url( $item, $content, $description );
+
+        $normalized[] = array(
+            'guid'        => $guid,
+            'link'        => $link,
+            'title'       => $title,
+            'date'        => $date,
+            'excerpt'     => $excerpt,
+            'image_url'   => $image_url,
+        );
+    }
+
+    set_transient( $transient_key, $normalized, SYOKA_CACHE_TTL );
+
+    return $normalized;
+}
+
+function syoka_extract_image_url( $item, $content, $description ) {
+    $media_thumbnail = $item->get_item_tags( SIMPLEPIE_NAMESPACE_MEDIARSS, 'thumbnail' );
+    if ( ! empty( $media_thumbnail[0]['attribs']['']['url'] ) ) {
+        return esc_url_raw( $media_thumbnail[0]['attribs']['']['url'] );
+    }
+
+    $media_content = $item->get_item_tags( SIMPLEPIE_NAMESPACE_MEDIARSS, 'content' );
+    if ( ! empty( $media_content[0]['attribs']['']['url'] ) ) {
+        return esc_url_raw( $media_content[0]['attribs']['']['url'] );
+    }
+
+    $enclosure = $item->get_enclosure();
+    if ( $enclosure && $enclosure->get_link() ) {
+        return esc_url_raw( $enclosure->get_link() );
+    }
+
+    $html = '';
+    if ( ! empty( $content ) ) {
+        $html = $content;
+    } elseif ( ! empty( $description ) ) {
+        $html = $description;
+    }
+
+    if ( ! empty( $html ) ) {
+        if ( preg_match( '/<img[^>]+src=["\']([^"\']+)["\']/i', $html, $matches ) ) {
+            return esc_url_raw( $matches[1] );
+        }
+    }
+
+    return '';
+}
+
+function syoka_clear_feed_cache( $feed_url ) {
+    $feed_url = esc_url_raw( $feed_url );
+    if ( empty( $feed_url ) ) {
+        return;
+    }
+    delete_transient( 'syoka_feed_' . md5( $feed_url ) );
+}

--- a/syoka/includes/post.php
+++ b/syoka/includes/post.php
@@ -1,0 +1,126 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function syoka_is_duplicate( $guid, $link ) {
+    $meta_query = array( 'relation' => 'OR' );
+
+    if ( ! empty( $guid ) ) {
+        $meta_query[] = array(
+            'key'   => '_syoka_source_guid',
+            'value' => $guid,
+        );
+    }
+
+    if ( ! empty( $link ) ) {
+        $meta_query[] = array(
+            'key'   => '_syoka_source_url',
+            'value' => $link,
+        );
+    }
+
+    if ( count( $meta_query ) === 1 ) {
+        return false;
+    }
+
+    $existing = get_posts(
+        array(
+            'post_type'      => 'post',
+            'post_status'    => array( 'draft', 'publish', 'pending', 'future', 'private' ),
+            'posts_per_page' => 1,
+            'meta_query'     => $meta_query,
+            'fields'         => 'ids',
+        )
+    );
+
+    return ! empty( $existing );
+}
+
+function syoka_create_draft_post( $item ) {
+    $guid = isset( $item['guid'] ) ? sanitize_text_field( $item['guid'] ) : '';
+    $link = isset( $item['link'] ) ? esc_url_raw( $item['link'] ) : '';
+
+    if ( syoka_is_duplicate( $guid, $link ) ) {
+        return array(
+            'status'  => 'duplicate',
+            'message' => __( 'Duplicate item skipped.', 'syoka' ),
+        );
+    }
+
+    $title = isset( $item['title'] ) ? sanitize_text_field( $item['title'] ) : '';
+    $excerpt = isset( $item['excerpt'] ) ? wp_kses_post( $item['excerpt'] ) : '';
+
+    $content_parts = array();
+    if ( ! empty( $excerpt ) ) {
+        $content_parts[] = $excerpt;
+    }
+
+    if ( ! empty( $link ) ) {
+        $content_parts[] = sprintf(
+            '<p><a href="%1$s" target="_blank" rel="noopener">%2$s</a></p>',
+            esc_url( $link ),
+            esc_html__( '元記事はこちら', 'syoka' )
+        );
+        $content_parts[] = sprintf(
+            '<p>%1$s: <a href="%2$s" target="_blank" rel="noopener">%2$s</a></p>',
+            esc_html__( '出典', 'syoka' ),
+            esc_url( $link )
+        );
+    }
+
+    $content = implode( "\n", $content_parts );
+
+    $post_id = wp_insert_post(
+        array(
+            'post_title'   => $title,
+            'post_content' => $content,
+            'post_status'  => 'draft',
+            'post_type'    => 'post',
+        ),
+        true
+    );
+
+    if ( is_wp_error( $post_id ) ) {
+        return array(
+            'status'  => 'error',
+            'message' => $post_id->get_error_message(),
+        );
+    }
+
+    update_post_meta( $post_id, '_syoka_source_url', $link );
+    update_post_meta( $post_id, '_syoka_source_guid', $guid );
+
+    $image_url = isset( $item['image_url'] ) ? esc_url_raw( $item['image_url'] ) : '';
+    $image_set = false;
+
+    if ( ! empty( $image_url ) ) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $attachment_id = media_sideload_image( $image_url, $post_id, null, 'id' );
+        if ( ! is_wp_error( $attachment_id ) ) {
+            set_post_thumbnail( $post_id, $attachment_id );
+            $image_set = true;
+        }
+    }
+
+    if ( ! $image_set ) {
+        $placeholder = '<div style="border:2px dashed #ccc; padding:12px; margin:0 0 16px; text-align:center; font-weight:700;">ここに画像が入ります（後で手動でアイキャッチを設定してください）</div>';
+        $updated_content = $placeholder . "\n" . get_post_field( 'post_content', $post_id );
+        wp_update_post(
+            array(
+                'ID'           => $post_id,
+                'post_content' => $updated_content,
+            )
+        );
+    }
+
+    return array(
+        'status'  => 'success',
+        'message' => __( 'Draft created.', 'syoka' ),
+        'post_id' => $post_id,
+    );
+}

--- a/syoka/syoka.php
+++ b/syoka/syoka.php
@@ -1,0 +1,34 @@
+<?php
+/*
+Plugin Name: Syoka
+Description: RSS候補を確認して選んで下書き投稿できる、手動確定型の紹介記事ドラフト生成プラグイン（最大10サイト／各5件）
+Version: 1.0.0
+Author: TaniyanR
+Text Domain: syoka
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'SYOKA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'SYOKA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'SYOKA_FEEDS_OPTION', 'syoka_feeds' );
+define( 'SYOKA_NOTICE_OPTION', 'syoka_admin_notices' );
+
+define( 'SYOKA_FEED_LIMIT', 10 );
+define( 'SYOKA_ITEMS_PER_FEED', 5 );
+define( 'SYOKA_CACHE_TTL', 10 * MINUTE_IN_SECONDS );
+
+require_once SYOKA_PLUGIN_DIR . 'includes/feed.php';
+require_once SYOKA_PLUGIN_DIR . 'includes/post.php';
+require_once SYOKA_PLUGIN_DIR . 'includes/admin.php';
+
+register_activation_hook( __FILE__, 'syoka_activate_plugin' );
+
+function syoka_activate_plugin() {
+    if ( ! get_option( SYOKA_FEEDS_OPTION ) ) {
+        add_option( SYOKA_FEEDS_OPTION, array() );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a WordPress plugin named "Syoka" that is recognized when uploaded as a ZIP and that allows admins to register RSS feeds and manually create draft posts from selected feed items. 
- Fix the common ZIP/plugin recognition issue by supplying a correct plugin entry file `syoka.php` with the required plugin header and the expected top-level `syoka/` folder structure.

### Description
- Add plugin bootstrap `syoka/syoka.php` with the required header, activation hook, and constants for options, limits, and cache TTL, and require the new `includes/` modules. 
- Implement `includes/feed.php` which uses `fetch_feed()` and SimplePie, caches per-site results in transients using keys `syoka_feed_{md5(url)}`, limits to 5 items per feed, and extracts image URLs in the required priority order (media:thumbnail, media:content, enclosure, first <img> in content/description).
- Implement `includes/post.php` which detects duplicates using `_syoka_source_guid` or `_syoka_source_url` post meta, creates `post` posts with status `draft`, sideloads and sets featured images via `media_sideload_image`/`set_post_thumbnail`, and inserts the required placeholder HTML at the top of the content when no image is available or image saving fails.
- Implement `includes/admin.php` which adds the admin menu pages `Syoka > RSSサイト管理` and `Syoka > 候補一覧`, handles feed add/edit/delete (max 10 enforced server-side), per-feed cache refresh (uses a nonce-protected refresh link), displays per-feed latest 5 items with thumbnail/title/link/date and checkbox selection, and processes batch creation of drafts with admin notices for success/duplicate/error; all admin operations require `manage_options` and proper nonces and use `esc_*/sanitize_*` functions.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981eeef5e648327bf5a6b126bdd6678)