### PR TITLE
Adjust feed handling, excerpt trimming, and draft content generation

### DIFF
--- a/syoka/includes/admin.php
+++ b/syoka/includes/admin.php
@@ -45,20 +45,26 @@ function syoka_handle_admin_actions() {
     if ( isset( $_POST['syoka_action'] ) && $_POST['syoka_action'] === 'save_feeds' ) {
         check_admin_referer( 'syoka_save_feeds' );
         syoka_handle_save_feeds();
+        wp_safe_redirect( admin_url( 'admin.php?page=syoka_feeds' ) );
+        exit;
     }
 
     if ( isset( $_GET['syoka_action'] ) && $_GET['syoka_action'] === 'refresh_feed' ) {
         check_admin_referer( 'syoka_refresh_feed' );
-        $feed_url = isset( $_GET['feed_url'] ) ? esc_url_raw( wp_unslash( $_GET['feed_url'] ) ) : '';
+        $feed_url = isset( $_GET['feed_url'] ) ? esc_url_raw( rawurldecode( wp_unslash( $_GET['feed_url'] ) ) ) : '';
         if ( ! empty( $feed_url ) ) {
             syoka_clear_feed_cache( $feed_url );
             syoka_add_notice( 'success', __( 'キャッシュを削除して再取得します。', 'syoka' ) );
         }
+        wp_safe_redirect( admin_url( 'admin.php?page=syoka_candidates' ) );
+        exit;
     }
 
     if ( isset( $_POST['syoka_action'] ) && $_POST['syoka_action'] === 'create_posts' ) {
         check_admin_referer( 'syoka_create_posts' );
         syoka_handle_create_posts();
+        wp_safe_redirect( admin_url( 'admin.php?page=syoka_candidates' ) );
+        exit;
     }
 }
 
@@ -276,7 +282,10 @@ function syoka_render_candidates_page() {
                     <?php
                     $items = syoka_get_feed_items( $feed['url'] );
                     if ( is_wp_error( $items ) ) {
-                        syoka_add_notice( 'error', sprintf( __( 'RSS取得に失敗しました: %s', 'syoka' ), esc_html( $items->get_error_message() ) ) );
+                        printf(
+                            '<div class="notice notice-error"><p>%s</p></div>',
+                            esc_html( sprintf( __( 'RSS取得に失敗しました (%1$s): %2$s', 'syoka' ), $feed['url'], $items->get_error_message() ) )
+                        );
                         $items = array();
                     }
                     ?>

--- a/syoka/includes/feed.php
+++ b/syoka/includes/feed.php
@@ -38,13 +38,7 @@ function syoka_get_feed_items( $feed_url, $force_refresh = false ) {
         $date = $item->get_date( 'Y-m-d H:i' );
         $content = $item->get_content();
         $description = $item->get_description();
-        $excerpt = '';
-
-        if ( ! empty( $description ) ) {
-            $excerpt = wp_kses_post( $description );
-        } elseif ( ! empty( $content ) ) {
-            $excerpt = wp_kses_post( $content );
-        }
+        $excerpt = syoka_build_excerpt( $description, $content );
 
         $image_url = syoka_extract_image_url( $item, $content, $description );
 
@@ -55,12 +49,42 @@ function syoka_get_feed_items( $feed_url, $force_refresh = false ) {
             'date'        => $date,
             'excerpt'     => $excerpt,
             'image_url'   => $image_url,
+            'feed_url'    => $feed_url,
         );
     }
 
     set_transient( $transient_key, $normalized, SYOKA_CACHE_TTL );
 
     return $normalized;
+}
+
+function syoka_build_excerpt( $description, $content ) {
+    $text = '';
+    if ( ! empty( $description ) ) {
+        $text = $description;
+    } elseif ( ! empty( $content ) ) {
+        $text = $content;
+    }
+
+    $text = wp_strip_all_tags( (string) $text );
+    $text = html_entity_decode( $text, ENT_QUOTES, get_bloginfo( 'charset' ) );
+    $text = preg_replace( '/\s+/u', ' ', $text );
+    $text = trim( $text );
+
+    if ( '' === $text ) {
+        return '';
+    }
+
+    $limit = 240;
+    if ( function_exists( 'mb_substr' ) ) {
+        if ( mb_strlen( $text ) > $limit ) {
+            $text = mb_substr( $text, 0, $limit );
+        }
+    } elseif ( strlen( $text ) > $limit ) {
+        $text = substr( $text, 0, $limit );
+    }
+
+    return $text;
 }
 
 function syoka_extract_image_url( $item, $content, $description ) {

--- a/syoka/includes/post.php
+++ b/syoka/includes/post.php
@@ -41,6 +41,7 @@ function syoka_is_duplicate( $guid, $link ) {
 function syoka_create_draft_post( $item ) {
     $guid = isset( $item['guid'] ) ? sanitize_text_field( $item['guid'] ) : '';
     $link = isset( $item['link'] ) ? esc_url_raw( $item['link'] ) : '';
+    $feed_url = isset( $item['feed_url'] ) ? esc_url_raw( $item['feed_url'] ) : '';
 
     if ( syoka_is_duplicate( $guid, $link ) ) {
         return array(
@@ -50,23 +51,27 @@ function syoka_create_draft_post( $item ) {
     }
 
     $title = isset( $item['title'] ) ? sanitize_text_field( $item['title'] ) : '';
-    $excerpt = isset( $item['excerpt'] ) ? wp_kses_post( $item['excerpt'] ) : '';
+    $excerpt = isset( $item['excerpt'] ) ? sanitize_text_field( $item['excerpt'] ) : '';
 
     $content_parts = array();
     if ( ! empty( $excerpt ) ) {
-        $content_parts[] = $excerpt;
+        $content_parts[] = sprintf( '<p>%s</p>', esc_html( $excerpt ) );
     }
 
     if ( ! empty( $link ) ) {
         $content_parts[] = sprintf(
             '<p><a href="%1$s" target="_blank" rel="noopener">%2$s</a></p>',
             esc_url( $link ),
-            esc_html__( '元記事はこちら', 'syoka' )
+            esc_html__( '元記事を読む', 'syoka' )
         );
+    }
+
+    $source_url = ! empty( $feed_url ) ? $feed_url : $link;
+    if ( ! empty( $source_url ) ) {
         $content_parts[] = sprintf(
             '<p>%1$s: <a href="%2$s" target="_blank" rel="noopener">%2$s</a></p>',
             esc_html__( '出典', 'syoka' ),
-            esc_url( $link )
+            esc_url( $source_url )
         );
     }
 


### PR DESCRIPTION
### Motivation
- Make feed-extracted excerpts consistent and size-limited for nicer draft content and avoid oversized descriptions. 
- Preserve the originating feed URL so drafts can show an accurate source when the item link differs. 
- Improve admin UX by redirecting after form actions and surfacing RSS fetch failures inline without breaking the candidates list. 

### Description
- Added `syoka_build_excerpt()` to `includes/feed.php` to strip tags, decode entities, normalize whitespace and trim excerpts to ~240 characters, and added `feed_url` into each normalized item. 
- Updated `syoka_get_feed_items()` to use the new excerpt builder and to cache normalized items in the existing transient key. 
- Enhanced `includes/admin.php` to `rawurldecode()` the feed URL on refresh, perform `wp_safe_redirect()` after saving feeds / refreshing a feed / creating drafts, and render RSS fetch failures as inline error notices while leaving the candidates list usable. 
- Adjusted `includes/post.php` to accept `feed_url` from the item, sanitize/store excerpts more strictly, wrap excerpts in `<p>` tags, change the link label to "元記事を読む", and prefer the feed URL for the `出典` attribution when available. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826942b96083279fc6a1a7779bad3b)