### PR TITLE
Fix feed item selection, duplicate detection, and image handling

### DIFF
--- a/syoka/includes/admin.php
+++ b/syoka/includes/admin.php
@@ -140,25 +140,68 @@ function syoka_handle_create_posts() {
         return;
     }
 
+    $selected = array();
     foreach ( $items as $encoded ) {
-        $decoded = json_decode( base64_decode( $encoded ), true );
-        if ( ! is_array( $decoded ) ) {
-            syoka_add_notice( 'error', __( '記事データの解析に失敗しました。', 'syoka' ) );
+        $encoded = sanitize_text_field( $encoded );
+        if ( '' === $encoded || false === strpos( $encoded, '|' ) ) {
+            continue;
+        }
+        list( $feed_url, $hash ) = explode( '|', $encoded, 2 );
+        $feed_url = esc_url_raw( rawurldecode( $feed_url ) );
+        $hash = sanitize_text_field( $hash );
+        if ( empty( $feed_url ) || empty( $hash ) ) {
+            continue;
+        }
+        if ( ! isset( $selected[ $feed_url ] ) ) {
+            $selected[ $feed_url ] = array();
+        }
+        $selected[ $feed_url ][] = $hash;
+    }
+
+    if ( empty( $selected ) ) {
+        syoka_add_notice( 'warning', __( '選択された記事がありません。', 'syoka' ) );
+        return;
+    }
+
+    foreach ( $selected as $feed_url => $hashes ) {
+        $hashes = array_values( array_unique( $hashes ) );
+
+        $feed_items = syoka_get_feed_items( $feed_url, true );
+        if ( is_wp_error( $feed_items ) ) {
+            syoka_add_notice(
+                'error',
+                esc_html( sprintf( __( 'RSS取得に失敗しました (%1$s): %2$s', 'syoka' ), $feed_url, $feed_items->get_error_message() ) )
+            );
             continue;
         }
 
-        $result = syoka_create_draft_post( $decoded );
-        if ( $result['status'] === 'success' ) {
-            $edit_link = get_edit_post_link( $result['post_id'], '' );
-            $message = __( '下書きを作成しました。', 'syoka' );
-            if ( $edit_link ) {
-                $message .= ' <a href="' . esc_url( $edit_link ) . '">' . esc_html__( '編集', 'syoka' ) . '</a>';
+        $item_map = array();
+        foreach ( $feed_items as $feed_item ) {
+            if ( empty( $feed_item['item_hash'] ) ) {
+                continue;
             }
-            syoka_add_notice( 'success', $message );
-        } elseif ( $result['status'] === 'duplicate' ) {
-            syoka_add_notice( 'warning', __( '既存投稿があるためスキップしました。', 'syoka' ) );
-        } else {
-            syoka_add_notice( 'error', sprintf( __( '作成に失敗しました: %s', 'syoka' ), esc_html( $result['message'] ) ) );
+            $item_map[ $feed_item['item_hash'] ] = $feed_item;
+        }
+
+        foreach ( $hashes as $hash ) {
+            if ( ! isset( $item_map[ $hash ] ) ) {
+                syoka_add_notice( 'error', __( '選択された記事が見つかりませんでした。', 'syoka' ) );
+                continue;
+            }
+
+            $result = syoka_create_draft_post( $item_map[ $hash ] );
+            if ( $result['status'] === 'success' ) {
+                $edit_link = get_edit_post_link( $result['post_id'], '' );
+                $message = __( '下書きを作成しました。', 'syoka' );
+                if ( $edit_link ) {
+                    $message .= ' <a href="' . esc_url( $edit_link ) . '">' . esc_html__( '編集', 'syoka' ) . '</a>';
+                }
+                syoka_add_notice( 'success', $message );
+            } elseif ( $result['status'] === 'duplicate' ) {
+                syoka_add_notice( 'warning', __( '既存投稿があるためスキップしました。', 'syoka' ) );
+            } else {
+                syoka_add_notice( 'error', sprintf( __( '作成に失敗しました: %s', 'syoka' ), esc_html( $result['message'] ) ) );
+            }
         }
     }
 }
@@ -324,14 +367,14 @@ function syoka_render_candidates_page() {
                                 <?php foreach ( $items as $item ) : ?>
                                     <?php
                                     $is_duplicate = syoka_is_duplicate( $item['guid'], $item['link'] );
-                                    $encoded = base64_encode( wp_json_encode( $item ) );
+                                    $item_hash = isset( $item['item_hash'] ) ? $item['item_hash'] : '';
                                     ?>
                                     <tr>
                                         <td>
-                                            <?php if ( $is_duplicate ) : ?>
+                                            <?php if ( $is_duplicate || empty( $item_hash ) ) : ?>
                                                 <input type="checkbox" disabled />
                                             <?php else : ?>
-                                                <input type="checkbox" name="syoka_items[]" value="<?php echo esc_attr( $encoded ); ?>" />
+                                                <input type="checkbox" name="syoka_items[]" value="<?php echo esc_attr( rawurlencode( $feed['url'] ) . '|' . $item_hash ); ?>" />
                                             <?php endif; ?>
                                         </td>
                                         <td>

--- a/syoka/includes/feed.php
+++ b/syoka/includes/feed.php
@@ -41,6 +41,7 @@ function syoka_get_feed_items( $feed_url, $force_refresh = false ) {
         $excerpt = syoka_build_excerpt( $description, $content );
 
         $image_url = syoka_extract_image_url( $item, $content, $description );
+        $item_hash = syoka_generate_item_hash( $guid, $link, $title, $date );
 
         $normalized[] = array(
             'guid'        => $guid,
@@ -50,12 +51,18 @@ function syoka_get_feed_items( $feed_url, $force_refresh = false ) {
             'excerpt'     => $excerpt,
             'image_url'   => $image_url,
             'feed_url'    => $feed_url,
+            'item_hash'   => $item_hash,
         );
     }
 
     set_transient( $transient_key, $normalized, SYOKA_CACHE_TTL );
 
     return $normalized;
+}
+
+function syoka_generate_item_hash( $guid, $link, $title, $date ) {
+    $primary = ! empty( $guid ) ? $guid : $link;
+    return md5( $primary . '|' . $title . '|' . $date );
 }
 
 function syoka_build_excerpt( $description, $content ) {

--- a/syoka/includes/post.php
+++ b/syoka/includes/post.php
@@ -5,23 +5,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 function syoka_is_duplicate( $guid, $link ) {
-    $meta_query = array( 'relation' => 'OR' );
-
     if ( ! empty( $guid ) ) {
-        $meta_query[] = array(
-            'key'   => '_syoka_source_guid',
-            'value' => $guid,
+        $meta_query = array(
+            array(
+                'key'   => '_syoka_source_guid',
+                'value' => $guid,
+            ),
         );
-    }
-
-    if ( ! empty( $link ) ) {
-        $meta_query[] = array(
-            'key'   => '_syoka_source_url',
-            'value' => $link,
+    } elseif ( ! empty( $link ) ) {
+        $meta_query = array(
+            array(
+                'key'   => '_syoka_source_url',
+                'value' => $link,
+            ),
         );
-    }
-
-    if ( count( $meta_query ) === 1 ) {
+    } else {
         return false;
     }
 
@@ -113,7 +111,7 @@ function syoka_create_draft_post( $item ) {
     }
 
     if ( ! $image_set ) {
-        $placeholder = '<div style="border:2px dashed #ccc; padding:12px; margin:0 0 16px; text-align:center; font-weight:700;">ここに画像が入ります（後で手動でアイキャッチを設定してください）</div>';
+        $placeholder = "<div style=\"border:2px dashed #ccc; padding:12px; margin:0 0 16px; text-align:center; font-weight:700;\">\nここに画像が入ります（後で手動でアイキャッチを設定してください）\n</div>";
         $updated_content = $placeholder . "\n" . get_post_field( 'post_content', $post_id );
         wp_update_post(
             array(

--- a/syoka/syoka.php
+++ b/syoka/syoka.php
@@ -15,7 +15,7 @@ define( 'SYOKA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SYOKA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 define( 'SYOKA_FEEDS_OPTION', 'syoka_feeds' );
-define( 'SYOKA_NOTICE_OPTION', 'syoka_admin_notices' );
+define( 'SYOKA_NOTICE_OPTION', 'syoka_notices' );
 
 define( 'SYOKA_FEED_LIMIT', 10 );
 define( 'SYOKA_ITEMS_PER_FEED', 5 );


### PR DESCRIPTION
### Motivation
- Remove ambiguity between two selection/transport schemes and make candidate selection robust by using `feed_url + item_hash` instead of embedding whole item payloads in the form.
- Ensure duplicate detection prefers GUID and falls back to URL to avoid creating duplicate posts.
- Make image handling predictable and insert the prescribed placeholder into the post content when no image can be set.

### Description
- Unified admin-side selection and submission to use `feed_url + item_hash` encoded as `rawurlencode(feed_url) . '|' . item_hash` and re-fetch the feed on submit to validate and map selected hashes back to items, implemented in `includes/admin.php` with selection sanitization and error notices.
- Added stable per-item hashes with `syoka_generate_item_hash()` and included `item_hash` in feed items returned by `syoka_get_feed_items()` in `includes/feed.php`.
- Made duplicate detection prefer GUID then URL by simplifying `syoka_is_duplicate()` to check GUID first and fall back to URL, implemented in `includes/post.php`.
- Ensured placeholder HTML is exactly the required multi-line string and is prepended to content when image download or setting fails, implemented in `includes/post.php`.
- Standardized the admin notices option name to `syoka_notices` via `SYOKA_NOTICE_OPTION` in `syoka/syoka.php` to match the expected option key used for one-time notices.

### Testing
- Searched repository for Git conflict markers with `rg -n "<<<<<<<|=======|>>>>>>>"` and confirmed none were found.
- Inspected the updated files (`syoka.php`, `includes/admin.php`, `includes/feed.php`, `includes/post.php`) with file viewers (`sed`/`nl`) to verify the intended changes were applied.
- Performed a static flow validation by exercising the selection-to-mapping logic in `includes/admin.php` (sanitization, splitting `feed_url|hash`, re-fetch via `syoka_get_feed_items(..., true)`), and checked that `syoka_generate_item_hash()` is present and used; these checks passed.
- No runtime/integration tests against a live WordPress instance were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826f9fa80c8327911b126754066eaa)